### PR TITLE
Repo is shared with Windows Forms, not WPF

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -1,5 +1,5 @@
 ﻿:name: Excel Engine
-:parent1: link:http://www.infragistics.com/help/wpf/[WPF]
+:parent1: link:http://www.infragistics.com/help/winforms/[Windows Forms]
 :parent2: link:http://www.infragistics.com/help/aspnet/[ASP.NET]
 
 image:http://www.infragistics.com/media/441501/horz_logo.png[alt="Infragistics, Inc."]
@@ -20,7 +20,7 @@ The best way to find the file you are looking for is to navigate to a page on th
 == Shared Repositories
 The following repositories use this repository to make a final help set:
 
-- link:http://www.github.com/infragistics/wpf-docs-en[WPF]
+- link:http://www.github.com/infragistics/winforms-docs-en[Windows Forms]
 - link:http://www.github.com/infragistics/aspnet-docs-en[ASP.NET]
 
 == API Documentation


### PR DESCRIPTION
This may change in 17.1 or future, but as of 16.2 it was only used in Windows Forms and ASP.NET.